### PR TITLE
Mount workspace to /workspace in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,8 @@
 		}
 	},
 	// Set *default* container specific settings.json values on container create.
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+	"workspaceFolder": "/workspace",
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/local/bin/python",


### PR DESCRIPTION
Mounts the vscode workspace to `/workspace` as expected by the `dev_install` script.