### PR TITLE
specify default config yaml via env var

### DIFF
--- a/tests/unit/fixtures/config.py
+++ b/tests/unit/fixtures/config.py
@@ -19,6 +19,7 @@ import copy
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict
 
 from pydantic import BaseModel, BaseSettings
@@ -29,19 +30,19 @@ from . import BASE_DIR, utils
 
 # read all config yamls:
 CONFIG_YAML_PATTERN = r"(.*)\.yaml"
-CONFIG_YAML_DIR = os.path.join(BASE_DIR, "config_yamls")
+CONFIG_YAML_DIR = BASE_DIR / "config_yamls"
 
 
 class ConfigYamlFixture(BaseModel):
     """Container for config yaml fixtures"""
 
-    path: str
+    path: Path
     content: Dict[str, Any]
 
 
 def read_config_yaml(name: str):
     """Read config yaml."""
-    path = os.path.join(CONFIG_YAML_DIR, name)
+    path = CONFIG_YAML_DIR / name
     content = utils.read_yaml(path)
 
     return ConfigYamlFixture(path=path, content=content)
@@ -81,7 +82,7 @@ class EnvVarFixture:
 
 def read_env_var_sets() -> Dict[str, EnvVarFixture]:
     """Read env vars sets and return a list of EnvVarFixtures."""
-    env_var_dict = utils.read_yaml(os.path.join(BASE_DIR, "config_env_var_sets.yaml"))
+    env_var_dict = utils.read_yaml(BASE_DIR / "config_env_var_sets.yaml")
 
     return {
         set_name: EnvVarFixture(env_vars=env_vars)

--- a/tests/unit/fixtures/utils.py
+++ b/tests/unit/fixtures/utils.py
@@ -15,10 +15,12 @@
 
 """Uitls for Fixture handling"""
 
+from pathlib import Path
+
 import yaml
 
 
-def read_yaml(path: str) -> dict:
+def read_yaml(path: Path) -> dict:
     """Read yaml file and return content as dict."""
     with open(path, "r") as file_:
         return yaml.safe_load(file_)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,8 +15,8 @@
 
 """Test config parsing module"""
 import os
-import pathlib
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -78,12 +78,12 @@ def test_config_from_yaml_and_env():
 def test_config_from_default_yaml(cwd: bool):
     """Test that default config yaml from home is correctly read"""
 
-    base_dir = os.getcwd() if cwd else pathlib.Path.home()
+    base_dir = Path(os.getcwd()) if cwd else Path.home()
     prefix = "test_prefix"
 
     # copy basic config to default config location:
     config_yaml = config_yamls["basic"]
-    default_yaml_path = os.path.join(str(base_dir), f".{prefix}.yaml")
+    default_yaml_path = base_dir / f".{prefix}.yaml"
     shutil.copy(config_yaml.path, default_yaml_path)
 
     # update config class with content of config yaml
@@ -92,6 +92,25 @@ def test_config_from_default_yaml(cwd: bool):
 
     # cleanup default config yaml:
     os.remove(default_yaml_path)
+
+    # compare to expected content:
+    expected = BasicConfig(**config_yaml.content)
+    assert config.dict() == expected
+
+
+def test_config_from_default_yaml_via_env():
+    """Test that default config yaml specified via an environment variable is correctly
+    read"""
+
+    prefix = "test_prefix"
+
+    # set env var:
+    config_yaml = config_yamls["basic"]
+    os.environ[f"{prefix.upper()}_CONFIG_YAML"] = str(config_yaml.path)
+
+    # update config class with content of config yaml
+    config_constructor = config_from_yaml(prefix=prefix)(BasicConfig)
+    config = config_constructor()
 
     # compare to expected content:
     expected = BasicConfig(**config_yaml.content)


### PR DESCRIPTION
Title for squash and merge:
```
specify default config yaml via env var
```

Description for squash and merge:
```
Before a default config yaml was expected to be located with
a specific name in either the CWD or the home dir.
This adds the possibility to specify the path to the config yaml via
an environment variable.
```