### PR TITLE
added test utils for postgresql

### DIFF
--- a/ghga_service_chassis_lib/postgresql_testing.py
+++ b/ghga_service_chassis_lib/postgresql_testing.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains utilities for testing code created with the functionality
+from the `postgresql` module.
+"""
+
+from testcontainers.postgres import PostgresContainer
+
+from .postgresql import PostgresqlConfigBase
+
+
+def config_from_psql_container(container: PostgresContainer) -> PostgresqlConfigBase:
+    """Prepares a PostgresqlConfigBase from an instance of a postgres test container."""
+    db_url = container.get_connection_url()
+    db_url_formatted = db_url.replace("postgresql+psycopg2", "postgresql")
+    return PostgresqlConfigBase(db_url=db_url_formatted)

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -65,7 +65,7 @@ EXCLUDE = [
 ]
 
 # exclude file by file ending from license header check:
-EXCLUDE_ENDINGS = ["json", "pyc", "yaml", "yml", "md"]
+EXCLUDE_ENDINGS = ["json", "pyc", "yaml", "yml", "md", "html", "xml"]
 
 # exclude any files with names that match any of the following regex:
 EXCLUDE_PATTERN = [r".*\.egg-info.*", r".*__cache__.*", r".*\.git.*"]

--- a/tests/integration/fixtures/postgresql.py
+++ b/tests/integration/fixtures/postgresql.py
@@ -22,9 +22,6 @@ from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.decl_api import DeclarativeMeta
-from testcontainers.postgres import PostgresContainer
-
-from ghga_service_chassis_lib.postgresql import PostgresqlConfigBase
 
 Base: DeclarativeMeta = declarative_base()
 
@@ -74,11 +71,3 @@ def populate_db(db_url: str):
             orm_entry = fixture_to_orm_model(entry)
             session.add(orm_entry)
         session.commit()
-
-
-def config_from_psql_container(container: PostgresContainer) -> PostgresqlConfigBase:
-    """Prepares a PostgresqlConfigBase from an instance of
-    postgres test container."""
-    db_url = container.get_connection_url()
-    db_url_formatted = db_url.replace("postgresql+psycopg2", "postgresql")
-    return PostgresqlConfigBase(db_url=db_url_formatted)

--- a/tests/integration/test_postgresql.py
+++ b/tests/integration/test_postgresql.py
@@ -25,12 +25,12 @@ from ghga_service_chassis_lib.postgresql import (
     AsyncPostgresqlConnector,
     SyncPostgresqlConnector,
 )
+from ghga_service_chassis_lib.postgresql_testing import config_from_psql_container
 
 from .fixtures.postgresql import (
     ADDITIONAL_TEST_DATA,
     PREPOPULATED_TEST_DATA,
     TestModel,
-    config_from_psql_container,
     fixture_to_orm_model,
     populate_db,
 )


### PR DESCRIPTION
Title for squash and merge:
```
added utils for testing based on postgresql
```

Description for squash and merge:
```
Adds a functions that prepares a PostgresqlConfigBase from 
an instance of a postgres test container.
Moreover, updated static file from the microservice template repo.
```