### PR TITLE
Feature/validate bucket and file ids

### DIFF
--- a/ghga_service_chassis_lib/s3.py
+++ b/ghga_service_chassis_lib/s3.py
@@ -39,6 +39,8 @@ from .object_storage_dao import (
     ObjectStorageDaoError,
     OutOfContextError,
     PresignedPostURL,
+    validate_bucket_id,
+    validate_object_id,
 )
 
 
@@ -129,12 +131,17 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
     An implementation of the ObjectStorageDao interface for interacting specifically
     with S3 object storages.
     Exceptions may include:
-        - BucketError, or derived exceptions:
-            - BucketNotFoundError
-            - BucketIdAlreadyInUse
-        - ObjectError, or derived exceptions:
-            - ObjectNotFoundError
-            - ObjectAlreadyExistsError
+        - NotImplementedError
+        - ObjectStorageDaoError, or derived exceptions:
+            - OutOfContextError (if the context manager protocol is not used correctly)
+            - BucketError, or derived exceptions:
+                - BucketIdValidationError
+                - BucketNotFoundError
+                - BucketAlreadyExists
+            - ObjectError, or derived exceptions:
+                - ObjectIdValidationError
+                - ObjectNotFoundError
+                - ObjectAlreadyExistsError
     """
 
     _out_of_context_error = OutOfContextError(context_manager_name="ObjectStorageS3")
@@ -204,6 +211,8 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
 
+        validate_bucket_id(bucket_id)
+
         try:
             bucket_list = self._client.list_buckets()
         except botocore.exceptions.ClientError as error:
@@ -237,6 +246,8 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
 
+        validate_bucket_id(bucket_id)
+
         self._assert_bucket_not_exists(bucket_id)
 
         try:
@@ -253,6 +264,8 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         """
         if not isinstance(self._resource, boto3.resources.factory.ServiceResource):
             raise self._out_of_context_error
+
+        validate_bucket_id(bucket_id)
 
         self._assert_bucket_exists(bucket_id)
 
@@ -277,6 +290,9 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
 
         if object_md5sum is not None:
             raise NotImplementedError("Md5 checking is not yet implemented.")
+
+        validate_bucket_id(bucket_id)
+        validate_object_id(object_id)
 
         try:
             _ = self._client.head_object(
@@ -325,6 +341,9 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
 
+        validate_bucket_id(bucket_id)
+        validate_object_id(object_id)
+
         self._assert_object_not_exists(bucket_id=bucket_id, object_id=object_id)
 
         conditions = (
@@ -362,6 +381,9 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
 
+        validate_bucket_id(bucket_id)
+        validate_object_id(object_id)
+
         self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
 
         try:
@@ -389,6 +411,11 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         """
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
+
+        validate_bucket_id(source_bucket_id)
+        validate_object_id(source_object_id)
+        validate_bucket_id(dest_bucket_id)
+        validate_object_id(dest_object_id)
 
         self._assert_object_exists(
             bucket_id=source_bucket_id, object_id=source_object_id
@@ -419,6 +446,9 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         """
         if not isinstance(self._client, botocore.client.BaseClient):
             raise self._out_of_context_error
+
+        validate_bucket_id(bucket_id)
+        validate_object_id(object_id)
 
         self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
 

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -65,7 +65,7 @@ EXCLUDE = [
 ]
 
 # exclude file by file ending from license header check:
-EXCLUDE_ENDINGS = ["json", "pyc", "yaml", "yml", "md"]
+EXCLUDE_ENDINGS = ["json", "pyc", "yaml", "yml", "md", "html", "xml"]
 
 # exclude any files with names that match any of the following regex:
 EXCLUDE_PATTERN = [r".*\.egg-info.*", r".*__cache__.*", r".*\.git.*"]

--- a/tests/unit/fixtures/object_storage_dao.py
+++ b/tests/unit/fixtures/object_storage_dao.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""fixtures for testing the `object_storage_dao` module"""
+
+too_long_id = "a" * 64
+too_short_id = "a1"

--- a/tests/unit/fixtures/object_storage_dao.py
+++ b/tests/unit/fixtures/object_storage_dao.py
@@ -15,5 +15,14 @@
 
 """fixtures for testing the `object_storage_dao` module"""
 
-too_long_id = "a" * 64
-too_short_id = "a1"
+TOO_LONG_ID = "a" * 64
+TOO_SHORT_ID = "a1"
+
+VALID_BUCKET_ID = "ghgas-12239992232323422"
+VALID_OBJECT_ID = "ghgaf-12239992232323422.test"
+
+BAD_CHARS_BUCKET_ID = ["_", ".", "/", "&", "+", ":"]
+BAD_CHARS_OBJECT_ID = ["_", "/", "&", "+", ":"]
+
+BAD_BUCKET_IDS = ["-aa", "aa-"]
+BAD_OBJECT_IDS = ["-aa", "aa-", ".aa", "aa."]

--- a/tests/unit/fixtures/object_storage_dao.py
+++ b/tests/unit/fixtures/object_storage_dao.py
@@ -21,7 +21,7 @@ TOO_SHORT_ID = "a1"
 VALID_BUCKET_ID = "ghgas-12239992232323422"
 VALID_OBJECT_ID = "ghgaf-12239992232323422.test"
 
-BAD_CHARS_BUCKET_ID = ["_", ".", "/", "&", "+", ":"]
+BAD_CHARS_BUCKET_ID = ["A", "_", ".", "/", "&", "+", ":"]
 BAD_CHARS_OBJECT_ID = ["_", "/", "&", "+", ":"]
 
 BAD_BUCKET_IDS = ["-aa", "aa-"]

--- a/tests/unit/test_object_storage_dao.py
+++ b/tests/unit/test_object_storage_dao.py
@@ -1,0 +1,93 @@
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this object except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `object_storage_dao` module."""
+
+import pytest
+
+from ghga_service_chassis_lib.object_storage_dao import (
+    BucketIdValidationError,
+    ObjectIdValidationError,
+    validate_bucket_id,
+    validate_object_id,
+)
+
+from .fixtures.object_storage_dao import too_long_id, too_short_id
+
+
+def test_validate_bucket_id():
+    """validate_bucket_id function: no error for valid id"""
+    validate_bucket_id("ghgas-12239992232323422")
+
+
+def test_validate_bucket_id_too_long():
+    """validate_bucket_id function: expect error for too long id"""
+    with pytest.raises(BucketIdValidationError):
+        validate_bucket_id(too_long_id)
+
+
+def test_validate_bucket_id_too_short():
+    """validate_bucket_id function: expect error for too short id"""
+    with pytest.raises(BucketIdValidationError):
+        validate_bucket_id(too_short_id)
+
+
+@pytest.mark.parametrize("non_allowed_char", ["_", ".", "/", "&", "+", ":"])
+def test_validate_bucket_id_non_allowed_chars(non_allowed_char):
+    """validate_bucket_id function: expect error for not allowed characters"""
+    with pytest.raises(BucketIdValidationError):
+        validate_bucket_id(f"a{non_allowed_char}a")
+
+
+def test_validate_bucket_id_non_allowed_ends():
+    """validate_bucket_id function: expect error for not allowed starting or tailing
+    characters"""
+    non_allowed_ids = ["-aa", "aa-"]
+    for id_ in non_allowed_ids:
+        with pytest.raises(BucketIdValidationError):
+            validate_bucket_id(id_)
+
+
+def test_validate_object_id():
+    """validate_object_id function: no error for valid id"""
+    validate_object_id("ghgaf-12239992232323422.test")
+
+
+def test_validate_object_id_too_long():
+    """validate_object_id function: expect error for too long id"""
+    with pytest.raises(ObjectIdValidationError):
+        validate_object_id(too_long_id)
+
+
+def test_validate_object_id_too_short():
+    """validate_object_id function: expect error for too short id"""
+    with pytest.raises(ObjectIdValidationError):
+        validate_object_id(too_short_id)
+
+
+@pytest.mark.parametrize("non_allowed_char", ["_", "/", "&", "+", ":"])
+def test_validate_object_id_non_allowed_chars(non_allowed_char: str):
+    """validate_object_id function: expect error for not allowed characters"""
+    with pytest.raises(ObjectIdValidationError):
+        validate_object_id(f"a{non_allowed_char}a")
+
+
+def test_validate_object_id_non_allowed_ends():
+    """validate_object_id function: expect error for not allowed starting or tailing
+    characters"""
+    non_allowed_ids = ["-aa", "aa-", ".aa", "aa."]
+    for id_ in non_allowed_ids:
+        with pytest.raises(ObjectIdValidationError):
+            validate_object_id(id_)

--- a/tests/unit/test_object_storage_dao.py
+++ b/tests/unit/test_object_storage_dao.py
@@ -24,70 +24,68 @@ from ghga_service_chassis_lib.object_storage_dao import (
     validate_object_id,
 )
 
-from .fixtures.object_storage_dao import too_long_id, too_short_id
+from .fixtures import object_storage_dao as osd_fixtures
 
 
 def test_validate_bucket_id():
     """validate_bucket_id function: no error for valid id"""
-    validate_bucket_id("ghgas-12239992232323422")
+    validate_bucket_id(osd_fixtures.VALID_BUCKET_ID)
 
 
 def test_validate_bucket_id_too_long():
     """validate_bucket_id function: expect error for too long id"""
     with pytest.raises(BucketIdValidationError):
-        validate_bucket_id(too_long_id)
+        validate_bucket_id(osd_fixtures.TOO_LONG_ID)
 
 
 def test_validate_bucket_id_too_short():
     """validate_bucket_id function: expect error for too short id"""
     with pytest.raises(BucketIdValidationError):
-        validate_bucket_id(too_short_id)
+        validate_bucket_id(osd_fixtures.TOO_SHORT_ID)
 
 
-@pytest.mark.parametrize("non_allowed_char", ["_", ".", "/", "&", "+", ":"])
+@pytest.mark.parametrize("non_allowed_char", osd_fixtures.BAD_CHARS_BUCKET_ID)
 def test_validate_bucket_id_non_allowed_chars(non_allowed_char):
     """validate_bucket_id function: expect error for not allowed characters"""
     with pytest.raises(BucketIdValidationError):
         validate_bucket_id(f"a{non_allowed_char}a")
 
 
-def test_validate_bucket_id_non_allowed_ends():
+@pytest.mark.parametrize("non_allowed_id", osd_fixtures.BAD_BUCKET_IDS)
+def test_validate_bucket_id_non_allowed_ends(non_allowed_id):
     """validate_bucket_id function: expect error for not allowed starting or tailing
     characters"""
-    non_allowed_ids = ["-aa", "aa-"]
-    for id_ in non_allowed_ids:
-        with pytest.raises(BucketIdValidationError):
-            validate_bucket_id(id_)
+    with pytest.raises(BucketIdValidationError):
+        validate_bucket_id(non_allowed_id)
 
 
 def test_validate_object_id():
     """validate_object_id function: no error for valid id"""
-    validate_object_id("ghgaf-12239992232323422.test")
+    validate_object_id(osd_fixtures.VALID_OBJECT_ID)
 
 
 def test_validate_object_id_too_long():
     """validate_object_id function: expect error for too long id"""
     with pytest.raises(ObjectIdValidationError):
-        validate_object_id(too_long_id)
+        validate_object_id(osd_fixtures.TOO_LONG_ID)
 
 
 def test_validate_object_id_too_short():
     """validate_object_id function: expect error for too short id"""
     with pytest.raises(ObjectIdValidationError):
-        validate_object_id(too_short_id)
+        validate_object_id(osd_fixtures.TOO_SHORT_ID)
 
 
-@pytest.mark.parametrize("non_allowed_char", ["_", "/", "&", "+", ":"])
+@pytest.mark.parametrize("non_allowed_char", osd_fixtures.BAD_CHARS_OBJECT_ID)
 def test_validate_object_id_non_allowed_chars(non_allowed_char: str):
     """validate_object_id function: expect error for not allowed characters"""
     with pytest.raises(ObjectIdValidationError):
         validate_object_id(f"a{non_allowed_char}a")
 
 
-def test_validate_object_id_non_allowed_ends():
+@pytest.mark.parametrize("non_allowed_id", osd_fixtures.BAD_OBJECT_IDS)
+def test_validate_object_id_non_allowed_ends(non_allowed_id):
     """validate_object_id function: expect error for not allowed starting or tailing
     characters"""
-    non_allowed_ids = ["-aa", "aa-", ".aa", "aa."]
-    for id_ in non_allowed_ids:
-        with pytest.raises(ObjectIdValidationError):
-            validate_object_id(id_)
+    with pytest.raises(ObjectIdValidationError):
+        validate_object_id(non_allowed_id)

--- a/tests/unit/test_object_storage_dao.py
+++ b/tests/unit/test_object_storage_dao.py
@@ -2,7 +2,7 @@
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this object except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Title for squash and merge:
```
add functions to validate bucket and object ids
```

Description for squash and merge:
```
Validate bucket and object ids roughly according to:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
These validation functions are used in the S3-specific ObjectStorageDao implementation
but they may also be used directly by a service to pre-check the ids.
```