### PR TITLE
add service_name to pubsub base params

### DIFF
--- a/examples/pub_sub/publisher.py
+++ b/examples/pub_sub/publisher.py
@@ -21,9 +21,7 @@
 import json
 from pathlib import Path
 
-import pika
-
-from ghga_service_chassis_lib.pubsub import AmqpTopic
+from ghga_service_chassis_lib.pubsub import AmqpTopic, PubSubConfigBase
 
 HERE = Path(__file__).parent.resolve()
 
@@ -36,10 +34,10 @@ def run():
         message_schema = json.load(schema_file)
 
     # create a topic object:
+    config = PubSubConfigBase(service_name="publisher")
     topic = AmqpTopic(
-        connection_params=pika.ConnectionParameters(host="rabbitmq"),
+        config=config,
         topic_name="my_topic",
-        service_name="publisher",
         json_schema=message_schema,
     )
 

--- a/examples/pub_sub/subscriber.py
+++ b/examples/pub_sub/subscriber.py
@@ -18,9 +18,7 @@
 import json
 from pathlib import Path
 
-import pika
-
-from ghga_service_chassis_lib.pubsub import AmqpTopic
+from ghga_service_chassis_lib.pubsub import AmqpTopic, PubSubConfigBase
 
 HERE = Path(__file__).parent.resolve()
 
@@ -39,10 +37,10 @@ def run():
         message_schema = json.load(schema_file)
 
     # create a topic object:
+    config = PubSubConfigBase(service_name="subscriber")
     topic = AmqpTopic(
-        connection_params=pika.ConnectionParameters(host="rabbitmq"),
+        config=config,
         topic_name="my_topic",
-        service_name="subscriber",
         json_schema=message_schema,
     )
 

--- a/ghga_service_chassis_lib/pubsub.py
+++ b/ghga_service_chassis_lib/pubsub.py
@@ -32,6 +32,7 @@ class PubSubConfigBase(BaseSettings):
     Inherit your config class from this class if you need
     to run an async PubSub API."""
 
+    service_name: str
     rabbitmq_host: str = "rabbitmq"
     rabbitmq_port: int = 5672
 

--- a/ghga_service_chassis_lib/pubsub.py
+++ b/ghga_service_chassis_lib/pubsub.py
@@ -17,9 +17,8 @@
 
 import json
 import logging
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Optional, Tuple, Type
+from typing import Callable, Optional, Tuple
 
 import jsonschema
 import pika
@@ -97,26 +96,9 @@ def callback_wrapper_factory(
     return callback
 
 
-@dataclass
 class AmqpTopic:
     """A base class to connect and iteract to/with a RabbitMQ host
     via the `topic` exchange type.
-
-    Args:
-        connection_params [Type(pika.connection.Parameters)]:
-            An object of class pika.connection.Parameters that configures
-            the connection to the RabbitMQ broker.
-        topic_name (str):
-            The name of the topic (only use letters, numbers, and "_").
-            The queue binding key as well as the names for the associated exchange
-            and queue will be derived from this string.
-        service_name (str):
-            A name that uniquely identifies the service. This will be used to
-            ensure that messages will not be duplicates between instances of
-            the same service.
-        json_schema (Optional[dict]):
-            Optional. If provided, the message body will be validated against this
-            json schema.
 
     Naming patterns for Exchanges and Queues:
         Exchanges will always be named according to the `topic_name`.
@@ -124,10 +106,31 @@ class AmqpTopic:
         and the `topic_name`
     """
 
-    connection_params: Type[pika.connection.Parameters]
-    topic_name: str
-    service_name: str
-    json_schema: Optional[dict] = None
+    def __init__(
+        self,
+        config: PubSubConfigBase,
+        topic_name: str,
+        json_schema: Optional[dict] = None,
+    ):
+        """Initialize the AMQP topic.
+
+        Args:
+            config [PubSubConfigBase]:
+                Config paramaters provided as PubSubConfigBase object.
+            topic_name (str):
+                The name of the topic (only use letters, numbers, and "_").
+                The queue binding key as well as the names for the associated exchange
+                and queue will be derived from this string.
+            json_schema (Optional[dict]):
+                Optional. If provided, the message body will be validated against this
+                json schema.
+        """
+        self.connection_params = pika.ConnectionParameters(
+            host=config.rabbitmq_host, port=config.rabbitmq_port
+        )
+        self.service_name = config.service_name
+        self.topic_name = topic_name
+        self.json_schema = json_schema
 
     def _create_channel_and_exchange(
         self,

--- a/tests/integration/fixtures/amqp.py
+++ b/tests/integration/fixtures/amqp.py
@@ -17,15 +17,12 @@
 
 import os
 
-import pika
-
 RABBITMQ_TEST_HOST = (
     os.getenv("RABBITMQ_TEST_HOST") if os.getenv("RABBITMQ_TEST_HOST") else "localhost"
 )
-CONNECTION_PARAMS = pika.ConnectionParameters(host=RABBITMQ_TEST_HOST)
 
 
-class MessageSuccessfullyReceived(Exception):
+class MessageSuccessfullyReceived(RuntimeError):
     """This Exception can be used to signal that the message
     was successfully received.
     """

--- a/tests/integration/test_pubsub.py
+++ b/tests/integration/test_pubsub.py
@@ -26,9 +26,9 @@ from time import sleep
 
 import pytest
 
-from ghga_service_chassis_lib.pubsub import AmqpTopic
+from ghga_service_chassis_lib.pubsub import AmqpTopic, PubSubConfigBase
 
-from .fixtures.amqp import CONNECTION_PARAMS, MessageSuccessfullyReceived
+from .fixtures.amqp import RABBITMQ_TEST_HOST, MessageSuccessfullyReceived
 from .fixtures.utils import set_timeout
 
 
@@ -48,9 +48,10 @@ def test_pub_sub():
 
         # create a topic object:
         topic = AmqpTopic(
-            connection_params=CONNECTION_PARAMS,
+            config=PubSubConfigBase(
+                rabbitmq_host=RABBITMQ_TEST_HOST, service_name="test_publisher"
+            ),
             topic_name=topic_name,
-            service_name="test_publisher",
             json_schema=None,
         )
 
@@ -65,9 +66,10 @@ def test_pub_sub():
 
     # receive the message:
     topic2 = AmqpTopic(
-        connection_params=CONNECTION_PARAMS,
+        config=PubSubConfigBase(
+            rabbitmq_host=RABBITMQ_TEST_HOST, service_name="test_subscriber"
+        ),
         topic_name=topic_name,
-        service_name="test_subscriber",
         json_schema=None,
     )
 


### PR DESCRIPTION
Title for squash and merge:
```
extend PubSubConfigBase and use it in AmqpTopic class
```

Description for squash and merge:
```
Added service_name to PubSubConfigBase. 
Moreover, the AmqpTopic class now uses this PubSubConfigBase
for providing essential config parameters.
```