### PR TITLE
Feature/subscribe non blocking gdev 386

### DIFF
--- a/examples/pub_sub/subscriber.py
+++ b/examples/pub_sub/subscriber.py
@@ -45,7 +45,7 @@ def run():
     )
 
     # subscribe:
-    topic.subscribe_for_ever(exec_on_message=process_message)
+    topic.subscribe(exec_on_message=process_message)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_pubsub.py
+++ b/tests/integration/test_pubsub.py
@@ -24,12 +24,8 @@ import multiprocessing
 from datetime import datetime
 from time import sleep
 
-import pytest
-
 from ghga_service_chassis_lib.pubsub import AmqpTopic, PubSubConfigBase
 from ghga_service_chassis_lib.pubsub_testing import RabbitMqContainer
-
-from .fixtures.amqp import MessageSuccessfullyReceived
 
 
 def test_pub_sub():
@@ -82,7 +78,5 @@ def test_pub_sub():
         def process_message(message_received: dict):
             """proccess the message"""
             assert message_received == test_message
-            raise MessageSuccessfullyReceived()
 
-        with pytest.raises(MessageSuccessfullyReceived):
-            topic2.subscribe_for_ever(exec_on_message=process_message)
+        topic2.subscribe(exec_on_message=process_message, run_forever=False)


### PR DESCRIPTION
Title for squash and merge:
```
option to only consume one message (GDEV-386)
```

Description for squash and merge:
```
When subscribing to a topic, implemented the option to only
consume one message and then terminate. This feature comes handy
for testing a subscribing function because you can tell it to not block
for ever.
```