### PR TITLE
Typos. Typos everywhere

### DIFF
--- a/ghga_service_chassis_lib/object_storage_dao.py
+++ b/ghga_service_chassis_lib/object_storage_dao.py
@@ -304,7 +304,7 @@ class ObjectStorageDao(DaoGenericBase):
     def get_part_upload_url(
         self, upload_id: str, bucket_id: str, object_id: str, part_number: int
     ) -> str:
-        """Given a id of an instatiated multipart upload along with the corresponding
+        """Given a id of an instantiated multipart upload along with the corresponding
         bucket and object ID, it returns a presign URL for uploading a file part with the
         specified number.
         Please note: the part number must be a non-zero, positive integer and parts

--- a/ghga_service_chassis_lib/object_storage_dao.py
+++ b/ghga_service_chassis_lib/object_storage_dao.py
@@ -293,7 +293,7 @@ class ObjectStorageDao(DaoGenericBase):
         """
         raise NotImplementedError()
 
-    def init_mulitpart_upload(
+    def init_multipart_upload(
         self,
         bucket_id: str,
         object_id: str,
@@ -304,7 +304,7 @@ class ObjectStorageDao(DaoGenericBase):
     def get_part_upload_url(
         self, upload_id: str, bucket_id: str, object_id: str, part_number: int
     ) -> str:
-        """Given a id of an instatiated mulitpart upload along with the corresponding
+        """Given a id of an instatiated multipart upload along with the corresponding
         bucket and object ID, it returns a presign URL for uploading a file part with the
         specified number.
         Please note: the part number must be a non-zero, positive integer and parts
@@ -313,7 +313,7 @@ class ObjectStorageDao(DaoGenericBase):
         raise NotImplementedError()
 
     # pylint: disable=too-many-arguments
-    def complete_mulitpart_upload(
+    def complete_multipart_upload(
         self,
         upload_id: str,
         bucket_id: str,

--- a/ghga_service_chassis_lib/object_storage_dao_testing.py
+++ b/ghga_service_chassis_lib/object_storage_dao_testing.py
@@ -100,7 +100,7 @@ def upload_part(
     content: bytes,
     part_number: int = 1,
 ):
-    """Upload the specified content as part to an initialized mulitpart upload."""
+    """Upload the specified content as part to an initialized multipart upload."""
 
     upload_url = storage_dao.get_part_upload_url(
         upload_id=upload_id,
@@ -123,7 +123,7 @@ def upload_part_of_size(
 ):
     """
     Generate a bytes object of the specified size and uploads the part to an initialized
-    mulitpart upload.
+    multipart upload.
     """
     content = b"\0" * size
     upload_part(
@@ -148,7 +148,7 @@ def multipart_upload_file(
     check_part_size(file_path=file_path, anticipated_size=part_size)
 
     print(f" - initiate multipart upload for test object {object_id}")
-    upload_id = storage_dao.init_mulitpart_upload(
+    upload_id = storage_dao.init_multipart_upload(
         bucket_id=bucket_id, object_id=object_id
     )
 
@@ -171,8 +171,8 @@ def multipart_upload_file(
                 part_number=part_number,
             )
 
-    print(" - complete mulitpart upload")
-    storage_dao.complete_mulitpart_upload(
+    print(" - complete multipart upload")
+    storage_dao.complete_multipart_upload(
         upload_id=upload_id,
         bucket_id=bucket_id,
         object_id=object_id,

--- a/ghga_service_chassis_lib/s3.py
+++ b/ghga_service_chassis_lib/s3.py
@@ -407,7 +407,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
             url=presigned_url["url"], fields=presigned_url["fields"]
         )
 
-    def _assert_mulitpart_upload_exist(
+    def _assert_multipart_upload_exist(
         self, upload_id: str, bucket_id: str, object_id: str
     ) -> None:
         """Checks if a multipart upload with the given ID exists and whether it maps
@@ -442,7 +442,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
             object_id=object_id,
         )
 
-    def init_mulitpart_upload(self, bucket_id: str, object_id: str) -> str:
+    def init_multipart_upload(self, bucket_id: str, object_id: str) -> str:
         """Initiates a mulipart upload procedure. Returns the upload ID."""
         if not isinstance(self._client, botocore.client.BaseClient):
             raise OutOfContextError()
@@ -461,7 +461,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
     def get_part_upload_url(
         self, upload_id: str, bucket_id: str, object_id: str, part_number: int
     ) -> str:
-        """Given a id of an instatiated mulitpart upload along with the corresponding
+        """Given a id of an instatiated multipart upload along with the corresponding
         bucket and object ID, it returns a presign URL for uploading a file part with the
         specified number.
         Please note: the part number must be a non-zero, positive integer and parts
@@ -476,7 +476,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
                 + " smaller or equal to 10000"
             )
 
-        self._assert_mulitpart_upload_exist(
+        self._assert_multipart_upload_exist(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
 
@@ -506,7 +506,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
         if not isinstance(self._client, botocore.client.BaseClient):
             raise OutOfContextError()
 
-        self._assert_mulitpart_upload_exist(
+        self._assert_multipart_upload_exist(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
 
@@ -605,7 +605,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
                 )
 
     # pylint: disable=too-many-arguments
-    def complete_mulitpart_upload(
+    def complete_multipart_upload(
         self,
         upload_id: str,
         bucket_id: str,

--- a/ghga_service_chassis_lib/s3.py
+++ b/ghga_service_chassis_lib/s3.py
@@ -461,7 +461,7 @@ class ObjectStorageS3(ObjectStorageDao):  # pylint: disable=too-many-instance-at
     def get_part_upload_url(
         self, upload_id: str, bucket_id: str, object_id: str, part_number: int
     ) -> str:
-        """Given a id of an instatiated multipart upload along with the corresponding
+        """Given a id of an instantiated multipart upload along with the corresponding
         bucket and object ID, it returns a presign URL for uploading a file part with the
         specified number.
         Please note: the part number must be a non-zero, positive integer and parts

--- a/ghga_service_chassis_lib/s3_testing.py
+++ b/ghga_service_chassis_lib/s3_testing.py
@@ -219,7 +219,7 @@ def get_initialized_upload(s3_fixture: S3Fixture):
 
     bucket_id = s3_fixture.existing_buckets[0]
     object_id = s3_fixture.non_existing_objects[0].object_id
-    upload_id = s3_fixture.storage.init_mulitpart_upload(
+    upload_id = s3_fixture.storage.init_multipart_upload(
         bucket_id=bucket_id, object_id=object_id
     )
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -185,13 +185,13 @@ def test_using_non_existing_upload(
     bucket_id = real_bucket_id if bucket_id_correct else "wrong-bucket"
     object_id = real_object_id if object_id_correct else "wrong-object"
     calls = [
-        lambda: s3_fixture.storage._assert_mulitpart_upload_exist(
+        lambda: s3_fixture.storage._assert_multipart_upload_exist(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         ),
         lambda: s3_fixture.storage.get_part_upload_url(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id, part_number=1
         ),
-        lambda: s3_fixture.storage.complete_mulitpart_upload(
+        lambda: s3_fixture.storage.complete_multipart_upload(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         ),
     ]
@@ -284,7 +284,7 @@ def test_complete_multipart_upload(
         )
 
     with (pytest.raises(exception) if exception else nullcontext()):  # type: ignore
-        s3_fixture.storage.complete_mulitpart_upload(
+        s3_fixture.storage.complete_multipart_upload(
             upload_id=upload_id,
             bucket_id=bucket_id,
             object_id=object_id,


### PR DESCRIPTION
Fixed typos in chassis lib:

`multipart` instead of `mulitpart`
`instantiated` instead of `instatiated`
