### PR TITLE
pin localstack to v. 0.14.2 (GDEV-882)

### DIFF
--- a/ghga_service_chassis_lib/s3_testing.py
+++ b/ghga_service_chassis_lib/s3_testing.py
@@ -97,7 +97,7 @@ def s3_fixture_factory(
     @pytest.fixture
     def s3_fixture() -> Generator[S3Fixture, None, None]:
         """Pytest fixture for tests depending on the ObjectStorageS3 DAO."""
-        with LocalStackContainer(image="localstack/localstack:0.11.4").with_services(
+        with LocalStackContainer(image="localstack/localstack:0.14.2").with_services(
             "s3"
         ) as localstack:
             config = config_from_localstack_container(localstack)


### PR DESCRIPTION
Solves problem with using range headers when performing multipart downloads.