### PR TITLE
configure http exception handler (GDEV-992)

### DIFF
--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/ghga_service_chassis_lib/api.py
+++ b/ghga_service_chassis_lib/api.py
@@ -21,6 +21,7 @@ from typing import Dict, Literal, Optional, Sequence, Union
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from httpyexpect.server.handlers.fastapi_ import configure_exception_handler
 from pydantic import BaseSettings, Field
 
 # type alias for log level parameter
@@ -130,6 +131,9 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
         kwargs["allow_credentials"] = config.cors_allow_credentials
 
     app.add_middleware(CORSMiddleware, **kwargs)
+
+    # Configure the exception handler to issue error according to httpyexpect model:
+    configure_exception_handler(app)
 
 
 def run_server(app: Union[str, FastAPI], config: ApiConfigBase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ console_scripts =
 api =
     fastapi==0.73.0
     uvicorn[standard]==0.17.4
+    httpyexpect==0.1.0
 kafka =
     kafka-python==2.0.2
     jsonschema==3.2.0


### PR DESCRIPTION
When configuring a FastAPI app also configure the the exception handler
so that HTTP error responses are modelled according to httpyepect.