### PR TITLE
use outer event loop when running server (GDEV-1359)

### DIFF
--- a/examples/api/hello_world_web_server/__main__.py
+++ b/examples/api/hello_world_web_server/__main__.py
@@ -15,6 +15,8 @@
 
 """Entrypoint of the package"""
 
+import asyncio
+
 from ghga_service_chassis_lib.api import run_server
 
 from .api import app  # noqa: F401 pylint: disable=unused-import
@@ -23,7 +25,9 @@ from .config import get_config
 
 def run():
     """Run the service"""
-    run_server(app="hello_world_web_server.__main__:app", config=get_config())
+    asyncio.run(
+        run_server(app="hello_world_web_server.__main__:app", config=get_config())
+    )
 
 
 if __name__ == "__main__":

--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.14.5"
+__version__ = "0.15.0"

--- a/ghga_service_chassis_lib/api.py
+++ b/ghga_service_chassis_lib/api.py
@@ -136,19 +136,19 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
     configure_exception_handler(app)
 
 
-async def run_server(app: FastAPI, config: ApiConfigBase):
+async def run_server(app: Union[FastAPI, str], config: ApiConfigBase):
     """Starts backend server. In contrast to the behavior of `uvicorn.run`, it does not
     create a new asyncio event loop but uses the outer one.
 
     Args:
-        app_import_path (str, Type[FastAPI]):
+        app_import_path:
             Either a FastAPI app object (auto reload and multiple
             workers won't work) or the import path to the app object.
             The path follows the same style that is also used for
             the console_scripts in a setup.py/setup.cfg
             (see here for an example:
             from ghga_service_chassis_lib.api import run_server).
-        config (BaseSettings):
+        config:
             A pydantic BaseSettings class that contains attributes
             "host", "port", and "log_level".
     """

--- a/ghga_service_chassis_lib/api.py
+++ b/ghga_service_chassis_lib/api.py
@@ -136,8 +136,9 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
     configure_exception_handler(app)
 
 
-def run_server(app: Union[str, FastAPI], config: ApiConfigBase):
-    """Starts backend server.
+async def run_server(app: FastAPI, config: ApiConfigBase):
+    """Starts backend server. In contrast to the behavior of `uvicorn.run`, it does not
+    create a new asyncio event loop but uses the outer one.
 
     Args:
         app_import_path (str, Type[FastAPI]):
@@ -152,11 +153,13 @@ def run_server(app: Union[str, FastAPI], config: ApiConfigBase):
             "host", "port", and "log_level".
     """
 
-    uvicorn.run(
-        app,
+    uv_config = uvicorn.Config(
+        app=app,
         host=config.host,
         port=config.port,
         log_level=config.log_level,
         reload=config.auto_reload,
         workers=config.workers,
     )
+    server = uvicorn.Server(uv_config)
+    await server.serve()

--- a/scripts/update_static_files.py
+++ b/scripts/update_static_files.py
@@ -59,6 +59,10 @@ def run():
 
             remote_file_content = remote_file_request.text
             local_file_path = REPO_ROOT_DIR / Path(relative_file_path)
+            local_parent_dir = local_file_path.parent
+
+            if not local_parent_dir.exists():
+                local_parent_dir.mkdir(parents=True)
 
             with open(local_file_path, "w", encoding="utf8") as local_file:
                 local_file.write(remote_file_content)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -15,9 +15,11 @@
 
 """Test api module"""
 
+import asyncio
 import multiprocessing
 import time
 
+import pytest
 import requests
 
 from ghga_service_chassis_lib.api import ApiConfigBase, run_server
@@ -26,13 +28,14 @@ from .fixtures.hello_world_test_app import GREETING, app
 from .fixtures.utils import find_free_port
 
 
-def test_run_server():
+@pytest.mark.asyncio
+async def test_run_server():
     """Test the run_server wrapper function"""
     config = ApiConfigBase()
     config.port = find_free_port()
 
     process = multiprocessing.Process(
-        target=run_server, kwargs={"app": app, "config": config}
+        target=lambda: asyncio.run(run_server(app=app, config=config))
     )
     process.start()
 


### PR DESCRIPTION
Previously, the run_server function created a new asyncio event loop making it impossible to use an app that requires async construction logic. The new implementation solves the issue by using the outer event loop.

Please note, this introduces a backward incompatibility for relying applications.

Bump version to 0.15.0.

Co-authored-by: Christoph Zwerschke <cito@online.de>