### PR TITLE
Feature/adaptive part size gdev 1402

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,8 +101,8 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
-.env
+# Virtual environments and environment files
+*.env
 .venv
 env/
 venv/

--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/ghga_service_chassis_lib/s3.py
+++ b/ghga_service_chassis_lib/s3.py
@@ -201,7 +201,8 @@ def adapt_part_size(current_part_size: int, file_size: int) -> int:
     elif current_part_size > upper_bound:
         current_part_size = upper_bound
 
-    # powers of two from 8 MiB to 4 GiB
+    # powers of two from 8 MiB to 1024 MiBs, everything above would produce files
+    # over the limit
     part_size_candidates = [2**i * 1024**2 for i in range(3, 11)]
 
     if file_size / current_part_size > max_num_parts:

--- a/ghga_service_chassis_lib/s3.py
+++ b/ghga_service_chassis_lib/s3.py
@@ -180,11 +180,20 @@ def adapt_part_size(current_part_size: int, file_size: int) -> int:
     Args:
         current_part_size (int): currently chosen part size in bytes to be checked
         file_size (int): total file size in bytes
-    """
 
+    Raises:
+        ValueError if file size exceeds the maximum of 5 TiB
+    """
     lower_bound = 5 * 1024**2
     upper_bound = 5 * 1024**3
+    hard_upper_limit = 5 * 1024**4
     max_num_parts = 10_000
+
+    if file_size > hard_upper_limit:
+        raise ValueError(
+            f"""Provided file size of {file_size/1024**4:2.f}TiB
+            exceeds maximum allowed file size of 5 TiB"""
+        )
 
     # clamp to lower/upper bound, respectively
     if current_part_size < lower_bound:
@@ -193,16 +202,12 @@ def adapt_part_size(current_part_size: int, file_size: int) -> int:
         current_part_size = upper_bound
 
     # powers of two from 8 MiB to 4 GiB
-    part_size_candidates = [2**i * 1024**2 for i in range(3, 13)]
+    part_size_candidates = [2**i * 1024**2 for i in range(3, 11)]
 
     if file_size / current_part_size > max_num_parts:
         for part_size_candidate in part_size_candidates:
             if file_size / part_size_candidate <= 10_000:
                 return part_size_candidate
-        raise ValueError(
-            """Why are you trying to upload a >39 TiB file?
-            Please reevaluate your lifes choices and contact the local GHGA Admins."""
-        )
     return current_part_size
 
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -40,7 +40,7 @@ TiB = 1024**4
 )
 def test_adapt_part_size(part_size: int, file_size: int, expected_part_size: int):
     """Test code to dynamically adapt part size"""
-    with pytest.raises(ValueError) if file_size > 5 * TiB else nullcontext():
+    with pytest.raises(ValueError) if file_size > 5 * TiB else nullcontext():  # type: ignore
         adapted_part_size = adapt_part_size(
             current_part_size=part_size, file_size=file_size
         )

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,0 +1,47 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test S3 helper methods
+"""
+
+from contextlib import nullcontext
+
+import pytest
+
+from ghga_service_chassis_lib.s3 import adapt_part_size
+
+MiB = 1024**2
+GiB = 1024**3
+TiB = 1024**4
+
+
+@pytest.mark.parametrize(
+    "part_size, file_size, expected_part_size",
+    [
+        (16 * MiB, 10 * GiB, 16 * MiB),
+        (16 * MiB, 200 * GiB, 32 * MiB),
+        (4 * MiB, 10 * GiB, 5 * MiB),
+        (6 * GiB, 10 * GiB, 5 * GiB),
+        (16 * MiB, 10 * TiB, None),
+    ],
+)
+def test_adapt_part_size(part_size: int, file_size: int, expected_part_size: int):
+    """Test code to dynamically adapt part size"""
+    with pytest.raises(ValueError) if file_size > 5 * TiB else nullcontext():
+        adapted_part_size = adapt_part_size(
+            current_part_size=part_size, file_size=file_size
+        )
+        assert adapted_part_size == expected_part_size

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -21,7 +21,7 @@ from contextlib import nullcontext
 
 import pytest
 
-from ghga_service_chassis_lib.s3 import adapt_part_size
+from ghga_service_chassis_lib.s3 import calc_part_size
 
 MiB = 1024**2
 GiB = 1024**3
@@ -29,19 +29,24 @@ TiB = 1024**4
 
 
 @pytest.mark.parametrize(
-    "part_size, file_size, expected_part_size",
+    "preferred_part_size, file_size, expected_part_size",
     [
         (16 * MiB, 10 * GiB, 16 * MiB),
         (16 * MiB, 200 * GiB, 32 * MiB),
-        (4 * MiB, 10 * GiB, 5 * MiB),
-        (6 * GiB, 10 * GiB, 5 * GiB),
+        (4 * MiB, 10 * GiB, 8 * MiB),
+        (6 * GiB, 10 * GiB, 4 * GiB),
         (16 * MiB, 10 * TiB, None),
+        (None, 20 * MiB, 8 * MiB),
+        (None, 10 * GiB, 8 * MiB),
+        (None, 200 * GiB, 32 * MiB),
     ],
 )
-def test_adapt_part_size(part_size: int, file_size: int, expected_part_size: int):
+def test_calc_part_size(
+    preferred_part_size: int, file_size: int, expected_part_size: int
+):
     """Test code to dynamically adapt part size"""
     with pytest.raises(ValueError) if file_size > 5 * TiB else nullcontext():  # type: ignore
-        adapted_part_size = adapt_part_size(
-            current_part_size=part_size, file_size=file_size
+        adapted_part_size = calc_part_size(
+            preferred_part_size=preferred_part_size, file_size=file_size
         )
         assert adapted_part_size == expected_part_size


### PR DESCRIPTION
```
Added code to adapt part size dynamically:
1. Check if maximum file size (5 TiB) is exceeded and raise ValueError if so
2. Clamp input part size to lower bound (5 MiB) and upper bound (5 GiB)
3. Adjust part sizes to next fitting power of two, if more than 10.000 parts would be produced

Co-authored-by: KerstenBreuer <kersten-breuer@outlook.com>
```

Two things:
Do we want 8 or 16 MiB as dynamic minimum?
Do we want to clamp part size to S3 lower/upper limits or to the respective powers of 2 that we support?