### PR TITLE
Add datetime type with guaranteed UTC timezone

### DIFF
--- a/examples/api/hello_world_web_server/__main__.py
+++ b/examples/api/hello_world_web_server/__main__.py
@@ -18,6 +18,7 @@
 import asyncio
 
 from ghga_service_chassis_lib.api import run_server
+from ghga_service_chassis_lib.utils import assert_tz_is_utc
 
 from .api import app  # noqa: F401 pylint: disable=unused-import
 from .config import get_config
@@ -25,6 +26,7 @@ from .config import get_config
 
 def run():
     """Run the service"""
+    assert_tz_is_utc()
     asyncio.run(
         run_server(app="hello_world_web_server.__main__:app", config=get_config())
     )

--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.15.3"
+__version__ = "0.16.0"

--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -61,11 +61,11 @@ def test_typical_workflow(
         big_temp_file(size=20 * MEBIBYTE) if use_multipart_upload else nullcontext()
     ) as temp_file:
         object_fixture = (
-            ObjectFixture(
+            s3_fixture.non_existing_objects[0]
+            if temp_file is None
+            else ObjectFixture(
                 file_path=temp_file.name, bucket_id="", object_id="some-big-file"
             )
-            if use_multipart_upload
-            else s3_fixture.non_existing_objects[0]
         )
 
         typical_workflow(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,7 +21,7 @@ from zoneinfo import ZoneInfo
 from pydantic import BaseModel
 from pytest import mark, raises
 
-from ghga_service_chassis_lib.utils import DateTimeUTC, now_as_utc
+from ghga_service_chassis_lib.utils import UTC, DateTimeUTC, now_as_utc
 
 
 @mark.parametrize(
@@ -52,9 +52,9 @@ def test_does_not_accept_naive_datetimes(value):
     [
         "2022-11-15T12:00:00+00:00",
         "2022-11-15T12:00:00Z",
-        datetime(2022, 11, 15, 12, 0, 0, tzinfo=timezone.utc),
+        datetime(2022, 11, 15, 12, 0, 0, tzinfo=UTC),
         datetime.now(timezone.utc),
-        datetime.fromtimestamp(0, timezone.utc),
+        datetime.fromtimestamp(0, UTC),
     ],
 )
 def test_accept_aware_datetimes_in_utc(value):
@@ -92,16 +92,31 @@ def test_converts_datetimes_to_utc(value):
     model = Model(dt=value, du=value)
 
     assert model.dt.tzinfo is not None
-    assert model.dt.tzinfo is not timezone.utc
+    assert model.dt.tzinfo is not UTC
     assert model.dt.utcoffset() != timedelta(0)
-    assert model.du.tzinfo is timezone.utc
+    assert model.du.tzinfo is UTC
     assert model.du.utcoffset() == timedelta(0)
 
     assert model.dt == model.du
 
 
+def test_datetime_utc_constructor():
+    """Test the constructor for DateTimeUTC values."""
+
+    date = DateTimeUTC.construct(2022, 11, 15, 12, 0, 0)
+    assert isinstance(date, DateTimeUTC)
+    assert date.tzinfo is UTC
+    assert date.utcoffset() == timedelta(0)
+
+    date = DateTimeUTC.construct(2022, 11, 15, 12, 0, 0, tzinfo=UTC)
+    assert isinstance(date, DateTimeUTC)
+    assert date.tzinfo is UTC
+    assert date.utcoffset() == timedelta(0)
+
+
 def test_now_as_utc():
     """Test the now_as_utc function."""
-    assert isinstance(now_as_utc(), datetime)
-    assert now_as_utc().tzinfo is timezone.utc
+    assert isinstance(now_as_utc(), DateTimeUTC)
+    assert now_as_utc().tzinfo is UTC
+    assert now_as_utc().utcoffset() == timedelta(0)
     assert abs(now_as_utc().timestamp() - datetime.now().timestamp()) < 5

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,107 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the utils module."""
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from pydantic import BaseModel
+from pytest import mark, raises
+
+from ghga_service_chassis_lib.utils import DateTimeUTC, now_as_utc
+
+
+@mark.parametrize(
+    "value",
+    [
+        "2022-11-15 12:00:00",
+        "2022-11-15T12:00:00",
+        datetime(2022, 11, 15, 12, 0, 0),
+        datetime.now(),
+        datetime.utcnow(),
+        datetime.utcfromtimestamp(0),
+    ],
+)
+def test_does_not_accept_naive_datetimes(value):
+    """Test that DateTimeUTC does not accept naive datetimes."""
+
+    class Model(BaseModel):
+        """Test model"""
+
+        d: DateTimeUTC
+
+    with raises(ValueError, match="missing a timezone"):
+        Model(d=value)
+
+
+@mark.parametrize(
+    "value",
+    [
+        "2022-11-15T12:00:00+00:00",
+        "2022-11-15T12:00:00Z",
+        datetime(2022, 11, 15, 12, 0, 0, tzinfo=timezone.utc),
+        datetime.now(timezone.utc),
+        datetime.fromtimestamp(0, timezone.utc),
+    ],
+)
+def test_accept_aware_datetimes_in_utc(value):
+    """Test that DateTimeUTC does not accepts timezone aware UTC datetimes."""
+
+    class Model(BaseModel):
+        """Test model"""
+
+        dt: datetime
+        du: DateTimeUTC
+
+    model = Model(dt=value, du=value)
+
+    assert model.dt == model.du
+
+
+@mark.parametrize(
+    "value",
+    [
+        "2022-11-15T12:00:00+03:00",
+        "2022-11-15T12:00:00-03:00",
+        datetime(2022, 11, 15, 12, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+        datetime.now(ZoneInfo("Asia/Tokyo")),
+    ],
+)
+def test_converts_datetimes_to_utc(value):
+    """Test that DateTimeUTC converts other time zones to UTC."""
+
+    class Model(BaseModel):
+        """Test model"""
+
+        dt: datetime
+        du: DateTimeUTC
+
+    model = Model(dt=value, du=value)
+
+    assert model.dt.tzinfo is not None
+    assert model.dt.tzinfo is not timezone.utc
+    assert model.dt.utcoffset() != timedelta(0)
+    assert model.du.tzinfo is timezone.utc
+    assert model.du.utcoffset() == timedelta(0)
+
+    assert model.dt == model.du
+
+
+def test_now_as_utc():
+    """Test the now_as_utc function."""
+    assert isinstance(now_as_utc(), datetime)
+    assert now_as_utc().tzinfo is timezone.utc
+    assert abs(now_as_utc().timestamp() - datetime.now().timestamp()) < 5


### PR DESCRIPTION
- Add pydantic datetime type `DateTimeUTC` with guaranteed UTC timezone
- Add `assert_tz_is_utc()` to verify that UTC is the default timezone
- Add `now_as_utc()` to create the current datetime with UTC timezone
- Add some more type hints to the utils module and specify exported names in `__all__`