### PR TITLE
Reverted testcontainers to 3.4.1

### DIFF
--- a/ghga_service_chassis_lib/__init__.py
+++ b/ghga_service_chassis_lib/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the basic chassis functionality used in services of GHGA"""
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,9 @@ dev =
     mkdocs-material-extensions==1.1.1
     mkdocstrings==0.19.1
     mkdocstrings-python-legacy==0.2.3
-    testcontainers[kafka,mongo,postgresql]==3.4.2
+    # 3.4.1 -> 3.4.2 causes issues in hexkit, but 3.7.1 works again
+    # 3.7.1 currently does not work with ghga-connector and dcs
+    testcontainers[kafka,mongo,postgresql]==3.4.1
     typer==0.7.0
     sqlalchemy-utils==0.39.0
     sqlalchemy-stubs==0.4


### PR DESCRIPTION
3.4.2 seemd stable for connector, but broke hexkit
Reverting to 3.4.1 as last known stable